### PR TITLE
HoloHash Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,13 +23,14 @@ const sha256 = (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).d
 /* AgentId */
 const agentHoloHashb64 = "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
 Codec.AgentId.decodeToHoloHash( agentHoloHashb64 );
-// Buffer.from( "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp", "base64" );
+// Buffer.from( "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp", "base64" );
 
-Codec.AgentId.decode("uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
+const holoHashAgentId = "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
+Codec.AgentId.decode(holoHashAgentId);
 // Buffer.from( "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE", "base64" );
 
 const publicKeyb64 = "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE";
-const publicKeyBuffer            =  Buffer.from(publicKeyb64, "base64");
+const publicKeyBuffer =  Buffer.from(publicKeyb64, "base64");
 Codec.AgentId.encode(publicKeyBuffer);
 // "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
 
@@ -42,7 +43,7 @@ Codec.Digest.decode(hashString);
 const holoHashType = "entry";
 const rawBuffer = Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
 Codec.Digest.holoHashFromBuffer(holoHashType, rawBuffer);
-// Buffer.from("uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm", "base64");
+// Buffer.from("hCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm", "base64");
 
 const holoHashType = "entry";
 const rawBuffer = Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");

--- a/README.md
+++ b/README.md
@@ -26,13 +26,16 @@ const publicKey = new Uint8Array([
  198, 221, 144, 203,  23, 155, 141,
  142, 179, 124, 113
 ]);
-Codec.AgentId.fromPublicKey( publicKey );
-// Uint8Array([
-//     132,  32,  36, 161, 222, 128, 146, 233,
-//     128,  11, 197,  77,  22,   0, 199, 102,
-//     199, 105,  12,  19, 193,  24, 250,  79,
-//     198, 221, 144, 203,  23, 155, 141, 142,
-//     179, 124, 113, 144,  10,  68, 169
+const publicKeyBuffer            =  Buffer.from(publicKey);
+
+Codec.AgentId.holoHashFromPublicKey( publicKeyBuffer );
+// Buffer.from(agentId);
+// const agentId					= new Uint8Array([
+//   132,  32,  36, 161, 222, 128, 146, 233,
+//   128,  11, 197,  77,  22,   0, 199, 102,
+//   199, 105,  12,  19, 193,  24, 250,  79,
+//   198, 221, 144, 203,  23, 155, 141, 142,
+//   179, 124, 113, 144,  10,  68, 169
 // ]);
 
 
@@ -69,15 +72,29 @@ const messageBytes = Buffer.from("example 2");
 expect( Codec.Signature.encode(messageBytes) ).to.equal(base64String);
 
 
-const hashString = "QmNZAJfVYoCASiPc3uYZXrvhRFbxJLxG18R2Ga4ZXfP4kR";
-const hashBytes = await sha256(new Uint8Array([0xca, 0xfe]));
+const holoHashType = "entry";
+const hashString = "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+const dataBytes					= new Uint8Array([
+  88,	 43,  0,	 130,	130, 164, 145, 252,
+  50,	 36,  8,	 37,	143, 125, 49,	 95,
+  241, 139, 45,	 95,	183, 5,		123, 133,	
+  203, 141,	250, 107,	100, 170, 165, 193
+]);
+const dataBuffer            =  Buffer.from(dataBytes);
 
-expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBytes);
+expect(Codec.Digest.decode(hashString)).to.deep.equal(dataBuffer);
 
 
-const hashBytes = await sha256(new Uint8Array([0xba, 0xbe]));
-const hashString = "QmeTu8d5sUNULwS72NxLNTMhLZfPma4qcWvG2LqxiUz1Gf";
+expect(Codec.Digest.encode(holoHashType, buffer)).to.equal(hashString);
 
-expect( Codec.Digest.encode(hashBytes)).to.equal(hashString);
 
+const holoHashBytes					= new Uint8Array([
+  132, 33,  36,	 88,	43,  0,	 	130, 130,
+  164, 145, 252, 50,	36,  8,   37,	 143,
+  125, 49,  95,  241, 139, 45,  95,	 183,
+  5,	 123, 133, 203, 141, 250, 107, 100, 
+  170, 165, 193, 48,  200, 28,  230
+]);
+const holoHashBuffer = Buffer.from(holoHashBytes)
+expect(Codec.Digest.holoHashFromBuffer(dataBuffer)).to.deep.equal(holoHashBuffer);
 ```

--- a/README.md
+++ b/README.md
@@ -19,47 +19,47 @@ const { Codec } = require('@holo-host/cryptolib');
 
 const sha256 = (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
 
-const publicKey = new Uint8Array([
- 161, 222, 128, 146, 233, 128,  11,
- 197,  77,  22,   0, 199, 102, 199,
- 105,  12,  19, 193,  24, 250,  79,
- 198, 221, 144, 203,  23, 155, 141,
- 142, 179, 124, 113
-]);
-const publicKeyBuffer            =  Buffer.from(publicKey);
 
-Codec.AgentId.holoHashFromPublicKey( publicKeyBuffer );
-// Buffer.from(agentId);
-// const agentId					= new Uint8Array([
-//   132,  32,  36, 161, 222, 128, 146, 233,
-//   128,  11, 197,  77,  22,   0, 199, 102,
-//   199, 105,  12,  19, 193,  24, 250,  79,
-//   198, 221, 144, 203,  23, 155, 141, 142,
-//   179, 124, 113, 144,  10,  68, 169
-// ]);
-
+/* AgentId */
+const agentHoloHashb64 = "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
+Codec.AgentId.decodeToHoloHash( agentHoloHashb64 );
+// Buffer.from( "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp", "base64" );
 
 Codec.AgentId.decode("uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
-// Uint8Array([
-//     161, 222, 128, 146, 233, 128,  11,
-//     197,  77,  22,   0, 199, 102, 199,
-//     105,  12,  19, 193,  24, 250,  79,
-//     198, 221, 144, 203,  23, 155, 141,
-//     142, 179, 124, 113
-// ]);
+// Buffer.from( "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE", "base64" );
 
-
-const publicKey = new Uint8Array([
-   1,   2,   3,   4,   5,   6,   7,
-   8,   9,  10,  11,  12,  13,  14,
-  15,  16,  17,  18,  19,  20,  21,
-  22,  23,  24,  25,  26,  27,  28,
-  29,  30,  31,  32
-]);
-Codec.AgentId.encode(publicKey);
+const publicKeyb64 = "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE";
+const publicKeyBuffer            =  Buffer.from(publicKeyb64, "base64");
+Codec.AgentId.encode(publicKeyBuffer);
 // "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
 
 
+/* HoloHash */
+const hashString = "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+Codec.Digest.decode(hashString);
+// Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
+
+const holoHashType = "entry";
+const rawBuffer = Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
+Codec.Digest.holoHashFromBuffer(holoHashType, rawBuffer);
+// Buffer.from("uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm", "base64");
+
+const holoHashType = "entry";
+const rawBuffer = Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
+Codec.Digest.encode(holoHashType, rawBuffer);
+// uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm
+
+const holoHashType = "entry";
+const holoHashBuffer = Buffer.from("uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm", "base64");
+Codec.Digest.encode(holoHashType, holoHashBuffer);
+// uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm
+
+const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+Codec.Digest.holoHashStringFromB64(base64String);
+// "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q"
+
+
+/* Signature */
 const messageBytes = Buffer.from("example 1");
 const base64String = "ZXhhbXBsZSAx";
 
@@ -72,31 +72,23 @@ const messageBytes = Buffer.from("example 2");
 expect( Codec.Signature.encode(messageBytes) ).to.equal(base64String);
 
 
-const holoHashType = "entry";
-const hashString = "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
-const dataBytes					= new Uint8Array([
-  88,	 43,  0,	 130,	130, 164, 145, 252,
-  50,	 36,  8,	 37,	143, 125, 49,	 95,
-  241, 139, 45,	 95,	183, 5,		123, 133,	
-  203, 141,	250, 107,	100, 170, 165, 193
-]);
-const dataBuffer            =  Buffer.from(dataBytes);
+/* Digest */
+const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
+Codec.Digest.decode(hashString)
+// Buffer.from("eyJzdGVwcyI6eyJiYXNlIjo2NCwicHJvY2VzcyI6WyJkYXRhIHdpbGwgYmUgaGFzaGVkIGludG8gYSIsInNoYTI1NiBtdWx0aWhhc2ggdGhlbiIsImVuY29kZWQiXX0sInRlc3QiOiJpbmZvcm1hdGlvbiJ9", "base64")
 
-expect(Codec.Digest.decode(hashString)).to.deep.equal(dataBuffer);
+const jsonData				=  {
+    "test": "information",
+    "steps": {
+      "process": ["data will be hashed into a", "sha256 multihash then", "encoded"],
+      "base": 64
+    }
+  };
+Codec.Digest.encode(jsonData);
+// "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0="
 
+const base64Buffer = Buffer.from("eyJzdGVwcyI6eyJiYXNlIjo2NCwicHJvY2VzcyI6WyJkYXRhIHdpbGwgYmUgaGFzaGVkIGludG8gYSIsInNoYTI1NiBtdWx0aWhhc2ggdGhlbiIsImVuY29kZWQiXX0sInRlc3QiOiJpbmZvcm1hdGlvbiJ9", "base64" );
+Codec.Digest.encode(base64Buffer);
+// "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0="
 
-expect(Codec.Digest.encode(holoHashType, buffer)).to.equal(hashString);
-
-
-const holoHashBytes					= new Uint8Array([
-  132, 33,  36,	 88,	43,  0,	 	130, 130,
-  164, 145, 252, 50,	36,  8,   37,	 143,
-  125, 49,  95,  241, 139, 45,  95,	 183,
-  5,	 123, 133, 203, 141, 250, 107, 100, 
-  170, 165, 193, 48,  200, 28,  230
-]);
-const holoHashBuffer = Buffer.from(holoHashBytes)
-expect(Codec.Digest.holoHashFromBuffer(dataBuffer)).to.deep.equal(holoHashBuffer);
-
-expect(Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
 ```

--- a/README.md
+++ b/README.md
@@ -97,4 +97,6 @@ const holoHashBytes					= new Uint8Array([
 ]);
 const holoHashBuffer = Buffer.from(holoHashBytes)
 expect(Codec.Digest.holoHashFromBuffer(dataBuffer)).to.deep.equal(holoHashBuffer);
+
+expect(Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
 ```

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Codec.AgentId.holoHashFromPublicKey( publicKeyBuffer );
 // ]);
 
 
-Codec.AgentId.decode("uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
+Codec.AgentId.decode("hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
 // Uint8Array([
 //     161, 222, 128, 146, 233, 128,  11,
 //     197,  77,  22,   0, 199, 102, 199,
@@ -57,7 +57,7 @@ const publicKey = new Uint8Array([
   29,  30,  31,  32
 ]);
 Codec.AgentId.encode(publicKey);
-// "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
+// "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
 
 
 const messageBytes = Buffer.from("example 1");
@@ -73,7 +73,7 @@ expect( Codec.Signature.encode(messageBytes) ).to.equal(base64String);
 
 
 const holoHashType = "entry";
-const hashString = "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+const hashString = "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 const dataBytes					= new Uint8Array([
   88,	 43,  0,	 130,	130, 164, 145, 252,
   50,	 36,  8,	 37,	143, 125, 49,	 95,

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Codec.AgentId.holoHashFromPublicKey( publicKeyBuffer );
 // ]);
 
 
-Codec.AgentId.decode("hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
+Codec.AgentId.decode("uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp");
 // Uint8Array([
 //     161, 222, 128, 146, 233, 128,  11,
 //     197,  77,  22,   0, 199, 102, 199,
@@ -57,7 +57,7 @@ const publicKey = new Uint8Array([
   29,  30,  31,  32
 ]);
 Codec.AgentId.encode(publicKey);
-// "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
+// "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp"
 
 
 const messageBytes = Buffer.from("example 1");
@@ -73,7 +73,7 @@ expect( Codec.Signature.encode(messageBytes) ).to.equal(base64String);
 
 
 const holoHashType = "entry";
-const hashString = "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+const hashString = "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 const dataBytes					= new Uint8Array([
   88,	 43,  0,	 130,	130, 164, 145, 252,
   50,	 36,  8,	 37,	143, 125, 49,	 95,

--- a/package-lock.json
+++ b/package-lock.json
@@ -425,6 +425,19 @@
         "esprima": "^4.0.0"
       }
     },
+    "json-stable-stringify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+      "requires": {
+        "jsonify": "~0.0.0"
+      }
+    },
+    "jsonify": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+      "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
+    },
     "locate-path": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@holo-host/wasm-key-manager": "0.0.5",
     "base-x": "^3.0.7",
     "blakejs": "^1.1.0",
+    "json-stable-stringify": "^1.0.1",
     "multihashes": "0.4.15"
   },
   "devDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -81,17 +81,6 @@ const Codec = {
 		decode: (str) => base36.decode(str),
 		encode: (buf) => base36.encode(Buffer.from(buf)),
 	},
-	"Base64": {
-		decode: (base64) => {
-			const byteString = Buffer.from(base64, "base64").toString("binary");
-			const buffer = Buffer.alloc(byteString.length);
-			for(let i = 0; i < byteString.length; i++) {
-					buffer[i] = byteString.charCodeAt(i);
-			}
-			return buffer
-		},
-		encode: (buf) => Buffer.from(buf).toString("base64"),
-	},
 	"HoloHash": {
 		holoHashStringFromB64: (base64) => convert_b64_to_holohash_b64(base64),
 		holoHashFromBuffer: (holoHashType, buf) => {
@@ -113,7 +102,7 @@ const Codec = {
 				const holoHashPrefix = getHoloHashPrefix(holoHashType.toLowerCase());
 				if (Buffer.compare(compareBuf, holoHashPrefix) === 0) {
 					// encoding from holohash buffer
-					return "u" + Codec.HoloHash.holoHashStringFromB64(Codec.Base64.encode(buf));
+					return "u" + Codec.HoloHash.holoHashStringFromB64(Buffer.from(buf).toString("base64"));
 				} else {
 					throw new Error(`Unexpected buffer length of ${Buffer.byteLength(buf)}.  Buffer should be 32 bytes.`);
 				}
@@ -130,16 +119,16 @@ const Codec = {
 	},
 	"Signature": {
 		decode: (base64) => Buffer.from(base64, "base64"),
-		encode: (buf) => Codec.Base64.encode(Buffer.from(buf)),
+		encode: (buf) => Buffer.from(buf).toString("base64"),
 	},
 	"Digest": {
-		decode: (base64) => multihash.decode(Codec.Base64.decode(base64)).digest,
+		decode: (base64) => multihash.decode(Buffer.from(base64, "base64")).digest,
 		encode: (data) => {
 			let buf = data;
 			if(!Buffer.isBuffer(data) ) {
 				buf = Buffer.from( typeof data === "string" ? data : SerializeJSON( data ) );
 			}
-			return Codec.Base64.encode(Buffer.from(multihash.encode(buf, "sha2-256")));
+			return Buffer.from(multihash.encode(buf, "sha2-256")).toString("base64");
 		},
 	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -1,56 +1,118 @@
 const { KeyManager,
-	deriveSeedFrom }		= require('@holo-host/wasm-key-manager');
-const blake				= require('blakejs');
-const multihash				= require('multihashes');
-const base36				= require('base-x')("0123456789abcdefghijklmnopqrstuvwxyz");
+	deriveSeedFrom }		= require("@holo-host/wasm-key-manager");
+const blake				= require("blakejs");
+const multihash				= require("multihashes");
+const base36				= require("base-x")("0123456789abcdefghijklmnopqrstuvwxyz");
 
-const HOLO_HASH_AGENT_PREFIX		= new Uint8Array([0x84, 0x20, 0x24]);
+const HOLO_HASH_AGENT_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x20, 0x24]).buffer);
+const HOLO_HASH_HEADER_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x29, 0x24]).buffer);
+const HOLO_HASH_ENTRY_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x21, 0x24]).buffer);
+const HOLO_HASH_DNA_PREFIX		  = Buffer.from(new Uint8Array([0x84, 0x2d, 0x24]).buffer);
 
-function calc_dht_bytes ( pubkey ) {
-    if ( pubkey.length !== 32 )
-	throw new Error(`Unexpected pubkey length of ${pubkey.length}.  Should be 32 bytes`);
+const getHoloHashPrefix = holoHashType => {
+	let holoHashPrefix;
+	switch (holoHashType) {
+		case "header":
+			holoHashPrefix = HOLO_HASH_HEADER_PREFIX;
+			break;
+		case "entry":
+			holoHashPrefix = HOLO_HASH_ENTRY_PREFIX;
+			break;
+		case "dna":
+			holoHashPrefix = HOLO_HASH_DNA_PREFIX;
+			break;
+		default:
+			throw new Error("Received unsupported HoloHash Type in Codec.Digest : ", holoHashType);
+	}
+	return holoHashPrefix;
+}
 
-    const digest			= blake.blake2b( pubkey, null, 16 );
-    const dht_part			= Buffer.from([digest[0], digest[1], digest[2], digest[3]])
+function check_pub_key_length (pubkey) {
+	if (Buffer.byteLength(pubkey) !== 32)
+		throw new Error(`Unexpected pubkey length of ${Buffer.byteLength(pubkey)}.  Should be 32 bytes`);
+	return pubkey;
+}
 
-    for (let i of [4, 8, 12]) {
-	dht_part[0] ^= digest[i];
-	dht_part[1] ^= digest[i + 1];
-	dht_part[2] ^= digest[i + 2];
-	dht_part[3] ^= digest[i + 3];
-    }
+// Generate holohash 4 byte (or u32) dht "location" - used for checksum and dht sharding
+function calc_dht_bytes ( data ) {
+	const digest				= blake.blake2b( data, null, 16 );
+	const dht_part			= Buffer.from([digest[0], digest[1], digest[2], digest[3]])
 
-    return dht_part;
+	for (let i of [4, 8, 12]) {
+		dht_part[0] ^= digest[i];
+		dht_part[1] ^= digest[i + 1];
+		dht_part[2] ^= digest[i + 2];
+		dht_part[3] ^= digest[i + 3];
+	}
+
+	return dht_part;
 }
 
 const Codec = {
-    "AgentId": {
-	fromPublicKey: (buf) => {
+	"AgentId": {
+		holoHashFromPublicKey: (buf) => {
+			check_pub_key_length(buf);
 	    return Buffer.concat([
-		HOLO_HASH_AGENT_PREFIX,
-		buf,
-		calc_dht_bytes( buf )
+				HOLO_HASH_AGENT_PREFIX,
+				buf,
+				calc_dht_bytes(buf)
 	    ]);
+		},
+		decode: (base64) => {
+			return Buffer.from(base64.slice(1), "base64").slice(3,-4);
+		},
+		encode: (buf) => {
+	    return "u" + Codec.Base64.encode(Codec.AgentId.holoHashFromPublicKey(buf));
+		},
 	},
-        decode: (str) => {
-	    return Buffer.from(str.slice(1), "base64").slice(3,-4);
+	"Base36": {
+		decode: (str) => base36.decode(str),
+		encode: (buf) => base36.encode(Buffer.from(buf)),
 	},
-        encode: (buf) => {
-	    return "u" + Codec.AgentId.fromPublicKey(buf).toString("base64");
+	"Base58":{
+		decode: (str) => multihash.decode(multihash.fromB58String(str)).digest,
+		encode: (buf) => multihash.toB58String(multihash.encode(Buffer.from(buf), "sha2-256")),
 	},
-    },
-    "Base36": {
-	decode: (str) => base36.decode(str),
-	encode: (buf) => base36.encode(Buffer.from(buf)),
-    },
-    "Signature": {
-        decode: (str) => Buffer.from(str, 'base64'),
-        encode: (buf) => Buffer.from(buf).toString('base64'),
-    },
-    "Digest": {
-        decode: (str) => multihash.decode(multihash.fromB58String(str)).digest,
-        encode: (buf) => multihash.toB58String(multihash.encode(Buffer.from(buf), 'sha2-256')),
-    },
+	"Base64": {
+		decode: (base64) => {
+			const byteString = Buffer.from(base64, "base64").toString("binary");
+			const buffer = Buffer.alloc(byteString.length);
+			for(let i = 0; i < byteString.length; i++) {
+					buffer[i] = byteString.charCodeAt(i);
+			}
+			return buffer
+		},
+		encode: (buf) => {
+			const bytes = new Uint8Array(buf);
+			const len = bytes.byteLength;
+			let binary = "";
+			for (let i = 0; i < len; i++) {
+					binary += String.fromCharCode(bytes[i]);
+			}
+			const base64 = Buffer.from(binary, "binary").toString("base64");
+			return base64
+		},
+
+	},
+	"Signature": {
+		decode: (base64) => Buffer.from(base64, "base64"),
+		encode: (buf) => Codec.Base64.encode(Buffer.from(buf)),
+	},
+	"Digest": {
+		holoHashFromBuffer: (holoHashPrefix, buf) => {
+			return Buffer.concat([
+				holoHashPrefix,
+				buf,
+				calc_dht_bytes(buf)
+			]);
+	},
+		decodeToHoloHash:(base64) => Buffer.from(base64.slice(1), "base64"),
+		decode: (base64) => Buffer.from(base64.slice(1), "base64").slice(3,-4),
+		encode: (holoHashType, buf) => {
+			const holoHashPrefix = getHoloHashPrefix(holoHashType);
+			return "u" + Codec.Base64.encode(Codec.Digest.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)))
+		},
+	},
 };
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,10 @@ const Codec = {
 	    ]);
 		},
 		decode: (base64) => {
-			return Buffer.from(base64, "base64").slice(3,-4);
+			return Buffer.from(base64.slice(1), "base64").slice(3,-4);
 		},
 		encode: (buf) => {
-	    return Codec.Base64.encode(Codec.AgentId.holoHashFromPublicKey(buf));
+	    return "u" + Codec.Base64.encode(Codec.AgentId.holoHashFromPublicKey(buf));
 		},
 	},
 	"Base36": {
@@ -106,11 +106,11 @@ const Codec = {
 				calc_dht_bytes(buf)
 			]);
 	},
-		decodeToHoloHash:(base64) => Buffer.from(base64, "base64"),
-		decode: (base64) => Buffer.from(base64, "base64").slice(3,-4),
+		decodeToHoloHash:(base64) => Buffer.from(base64.slice(1), "base64"),
+		decode: (base64) => Buffer.from(base64.slice(1), "base64").slice(3,-4),
 		encode: (holoHashType, buf) => {
 			const holoHashPrefix = getHoloHashPrefix(holoHashType);
-			return Codec.Base64.encode(Codec.Digest.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)))
+			return "u" + Codec.Base64.encode(Codec.Digest.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)))
 		},
 	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -59,10 +59,10 @@ const Codec = {
 	    ]);
 		},
 		decode: (base64) => {
-			return Buffer.from(base64.slice(1), "base64").slice(3,-4);
+			return Buffer.from(base64, "base64").slice(3,-4);
 		},
 		encode: (buf) => {
-	    return "u" + Codec.Base64.encode(Codec.AgentId.holoHashFromPublicKey(buf));
+	    return Codec.Base64.encode(Codec.AgentId.holoHashFromPublicKey(buf));
 		},
 	},
 	"Base36": {
@@ -106,11 +106,11 @@ const Codec = {
 				calc_dht_bytes(buf)
 			]);
 	},
-		decodeToHoloHash:(base64) => Buffer.from(base64.slice(1), "base64"),
-		decode: (base64) => Buffer.from(base64.slice(1), "base64").slice(3,-4),
+		decodeToHoloHash:(base64) => Buffer.from(base64, "base64"),
+		decode: (base64) => Buffer.from(base64, "base64").slice(3,-4),
 		encode: (holoHashType, buf) => {
 			const holoHashPrefix = getHoloHashPrefix(holoHashType);
-			return "u" + Codec.Base64.encode(Codec.Digest.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)))
+			return Codec.Base64.encode(Codec.Digest.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)))
 		},
 	},
 };

--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const base36				= require("base-x")("0123456789abcdefghijklmnopqrstuvwxyz");
 const HOLO_HASH_AGENT_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x20, 0x24]).buffer);
 const HOLO_HASH_HEADER_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x29, 0x24]).buffer);
 const HOLO_HASH_ENTRY_PREFIX		= Buffer.from(new Uint8Array([0x84, 0x21, 0x24]).buffer);
-const HOLO_HASH_DNA_PREFIX		  = Buffer.from(new Uint8Array([0x84, 0x2d, 0x24]).buffer);
+const HOLO_HASH_DNA_PREFIX		    = Buffer.from(new Uint8Array([0x84, 0x2d, 0x24]).buffer);
 
 const getHoloHashPrefix = holoHashType => {
 	let holoHashPrefix;
@@ -94,7 +94,8 @@ const Codec = {
 	},
 	"HoloHash": {
 		holoHashStringFromB64: (base64) => convert_b64_to_holohash_b64(base64),
-		holoHashFromBuffer: (holoHashPrefix, buf) => {
+		holoHashFromBuffer: (holoHashType, buf) => {
+			const holoHashPrefix = getHoloHashPrefix(holoHashType);
 			check_length(Buffer.from(buf), 32);
 			return Buffer.concat([
 				holoHashPrefix,
@@ -103,10 +104,13 @@ const Codec = {
 			]);
 		},
 		encode: (holoHashType, buf) => {
-			const holoHashPrefix = getHoloHashPrefix(holoHashType);
+			if (typeof holoHashType !== 'string'){
+				throw new Error('First argument must be a string declaring the type of HoloHash to be encoded. Accepted HoloHash types are: header, entry, dna, and agent.')
+			}
 			if (Buffer.byteLength(buf) === 39) {
 				const compareBuf = Buffer.alloc(3);
 				buf.copy(compareBuf, 0, 0, 3);
+				const holoHashPrefix = getHoloHashPrefix(holoHashType.toLowerCase());
 				if (Buffer.compare(compareBuf, holoHashPrefix) === 0) {
 					// encoding from holohash buffer
 					return "u" + Codec.HoloHash.holoHashStringFromB64(Codec.Base64.encode(buf));
@@ -115,7 +119,7 @@ const Codec = {
 				}
 			} 
 			// encoding from raw buffer
-			const rawBase64 = Codec.HoloHash.holoHashFromBuffer(holoHashPrefix, Buffer.from(buf)).toString("base64");
+			const rawBase64 = Codec.HoloHash.holoHashFromBuffer(holoHashType.toLowerCase(), Buffer.from(buf)).toString("base64");
 			return "u" + Codec.HoloHash.holoHashStringFromB64(rawBase64);
 		},
 		decode: (base64) => {

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -74,37 +74,6 @@ describe("Codec.Base36", () => {
 	});
 });
 
-describe("Codec.Base64", () => {
-	it("should decode base64 string into buffer", async () => {
-		const hashString				= "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
-		const dataBytes					= new Uint8Array([
-			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
-			63,  7,   31,  208, 188,  164, 15,  85, 
-			43,  151, 1,   95, 	44, 	44,  114, 137, 
-			94,  184, 122, 101, 47, 	24,  85,  237,
-			140, 118, 203, 210, 129, 206,  234
-		]);
-		const hashBuf					 = Buffer.from(dataBytes)
-
-			expect( Codec.Base64.decode(hashString)).to.deep.equal(hashBuf);
-	});
-
-	it("should encode buffer into base64 string", async () => {
-		const dataBytes					= new Uint8Array([
-			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
-			63,  7,   31,  208, 188,  164, 15,  85, 
-			43,  151, 1,   95, 	44, 	44,  114, 137, 
-			94,  184, 122, 101, 47, 	24,  85,  237,
-			140, 118, 203, 210, 129, 206,  234
-		]);
-		const hashBuf					 = Buffer.from(dataBytes)
-		const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
-
-		expect( Codec.Base64.encode(hashBuf)).to.equal(base64String);
-	});
-});
-
-
 describe("Codec.Signature", () => {
 	it("should decode Signature string into message bytes", async () => {
 		const messageBytes				= Buffer.from("example 1");

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -1,25 +1,8 @@
-const crypto						= require('crypto');
 const expect						= require('chai').expect;
 
 const { Codec }						= require('../src/index.js');
 
-const sha256						= (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
-
 describe("Codec.AgentId", () => {
-	it("should decode HoloHash agent ID into public key bytes", () => {
-		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-		const publicKey					= new Uint8Array([
-			161, 222, 128, 146, 233, 128,  11,
-			197,  77,  22,   0, 199, 102, 199,
-			105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141,
-			142, 179, 124, 113
-		]);
-		const publicKeyBuffer            =  Buffer.from(publicKey);
-
-		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKeyBuffer);
-	})
-
 	it("should decode HoloHash agent ID into HoloHash agent pubkey buffer", async () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const holohashPubKey					= new Uint8Array([
@@ -31,10 +14,24 @@ describe("Codec.AgentId", () => {
 		]);
 		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
 
-		expect( Codec.Digest.decodeToHoloHash(agentId)).to.deep.equal(holohashPubKeyBuffer);
+		expect( Codec.AgentId.decodeToHoloHash(agentId)).to.deep.equal(holohashPubKeyBuffer);
 	});
 
-	it("should encode public key bytes into HoloHash agent ID", () => {
+	it("should decode HoloHash agent ID into public key buffer", () => {
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const publicKey					= new Uint8Array([
+			161, 222, 128, 146, 233, 128,  11,
+			197,  77,  22,   0, 199, 102, 199,
+			105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141,
+			142, 179, 124, 113
+		]);
+		const publicKeyBuffer            =  Buffer.from(publicKey);
+
+		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKeyBuffer);
+	});
+
+	it("should encode public key buffer into HoloHash agent ID", () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
@@ -46,20 +43,6 @@ describe("Codec.AgentId", () => {
 		const publicKeyBuffer            =  Buffer.from(publicKey);
 
 		expect( Codec.AgentId.encode(publicKeyBuffer)		).to.equal(agentId);
-	});
-
-	it("should encode HoloHash agent pubkey into HoloHash agent ID", () => {
-		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-		const holohashPubKey					= new Uint8Array([
-			132,  32,  36, 161, 222, 128, 146, 233,
-			128,  11, 197,  77,  22,   0, 199, 102,
-			199, 105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141, 142,
-			179, 124, 113, 144,  10,  68, 169
-		]);
-		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
-
-		expect( Codec.AgentId.encodeFromHoloHash(holohashPubKeyBuffer)		).to.equal(agentId);
 	});
 });
 
@@ -91,22 +74,6 @@ describe("Codec.Base36", () => {
 	});
 });
 
-describe("Codec.Base58", () => {
-	it("should decode SHA-256 multihash into SHA-256 digest bytes (with base58)", async () => {
-		const hashString				= "QmNZAJfVYoCASiPc3uYZXrvhRFbxJLxG18R2Ga4ZXfP4kR";
-		const hashBytes					= await sha256(new Uint8Array([0xca, 0xfe]));
-
-		expect( Codec.Base58.decode(hashString)).to.deep.equal(hashBytes);
-	});
-
-	it("should encode SHA-256 digest bytes into SHA-256 multihash (with base58)", async () => {
-		const hashBytes					= await sha256(new Uint8Array([0xba, 0xbe]));
-		const hashString				= "QmeTu8d5sUNULwS72NxLNTMhLZfPma4qcWvG2LqxiUz1Gf";
-
-		expect( Codec.Base58.encode(hashBytes)).to.equal(hashString);
-	});
-});
-
 describe("Codec.Base64", () => {
 	it("should decode base64 string into buffer", async () => {
 		const hashString				= "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
@@ -135,27 +102,6 @@ describe("Codec.Base64", () => {
 
 		expect( Codec.Base64.encode(hashBuf)).to.equal(base64String);
 	});
-
-	it("should get HoloHash base64 String from raw base64 string", async () => {
-		const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
-		const HHBase64String			 = "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
-
-		expect( Codec.Base64.base64ToHoloHashB64(base64String)).to.equal(HHBase64String);
-	});
-
-	it("should encode buffer into HoloHash base64 string", async () => {
-		const dataBytes					= new Uint8Array([
-			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
-			63,  7,   31,  208, 188,  164, 15,  85, 
-			43,  151, 1,   95, 	44, 	44,  114, 137, 
-			94,  184, 122, 101, 47, 	24,  85,  237,
-			140, 118, 203, 210, 129, 206,  234
-		]);
-		const hashBuf					 = Buffer.from(dataBytes)
-		const HHBase64String			 = "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
-
-		expect( Codec.Base64.encodeToHoloHashB64(hashBuf)).to.equal(HHBase64String);
-	});
 });
 
 
@@ -176,7 +122,14 @@ describe("Codec.Signature", () => {
 });
 
 describe("Codec.HoloHash", () => {
-	it("should get holohash buffer from raw buffer", () => {
+	it("should return HoloHash base64 String from raw base64 string", async () => {
+		const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+		const HHBase64String			 = "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+
+		expect( Codec.HoloHash.holoHashStringFromB64(base64String)).to.equal(HHBase64String);
+	});
+
+	it("should return holohash buffer from raw buffer", () => {
 		const dataBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,
@@ -214,60 +167,70 @@ describe("Codec.HoloHash", () => {
 	});
 
 	it("should encode raw buffer into HoloHash string", async () => {
-		const data					= new Uint8Array([
+		const bytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,
 			241, 139, 45,	 95,	183, 5,		123, 133,	
 			203, 141,	250, 107,	100, 170, 165, 193
 		]);
 
+		const buffer            =  Buffer.from(bytes);
+
 		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 
-		expect( Codec.HoloHash.encode('entry', data)).to.equal(hashString);
+		expect( Codec.HoloHash.encode('entry', buffer)).to.equal(hashString);
+	});
+
+	it("should encode holohash buffer into HoloHash string", async () => {
+		const holoHashBytes					= new Uint8Array([
+			132, 33,  36,	 88,	43,  0,	 	130, 130,
+			164, 145, 252, 50,	36,  8,   37,	 143,
+			125, 49,  95,  241, 139, 45,  95,	 183,
+			5,	 123, 133, 203, 141, 250, 107, 100, 
+			170, 165, 193, 48,  200, 28,  230
+		]);
+
+		const holoHashBuffer            =  Buffer.from(holoHashBytes);
+
+		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+
+		expect( Codec.HoloHash.encode('entry', holoHashBuffer)).to.equal(hashString);
 	});
 });
 
 
 describe("Codec.Digest", () => {
-	// it("should decode HoloHash string into raw buffer", async () => {
-	// 	const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
-	// 	const hashBytes					= new Uint8Array([
-	// 		88,	 43,  0,	 130,	130, 164, 145, 252,
-	// 		50,	 36,  8,	 37,	143, 125, 49,	 95,
-	// 		241, 139, 45,	 95,	183, 5,		123, 133,	
-	// 		203, 141,	250, 107,	100, 170, 165, 193
-	// 	]);
-	// 	const hashBuffer            =  Buffer.from(hashBytes)
+	it("should decode SHA-256 multihash into SHA-256 digest buffer", async () => {
+		const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
+		const hashBytes					= new Uint8Array([
+			123,34,115,116,101,112,115,34,58,123,34,98,97,115,101,34,58,54,52,44,34,112,114,111,99,101,115,115,34,58,91,34,100,97,116,97,32,119,105,108,108,32,98,101,32,104,97,115,104,101,100,32,105,110,116,111,32,97,34,44,34,115,104,97,50,53,54,32,109,117,108,116,105,104,97,115,104,32,116,104,101,110,34,44,34,101,110,99,111,100,101,100,34,93,125,44,34,116,101,115,116,34,58,34,105,110,102,111,114,109,97,116,105,111,110,34,125
+		]);
+		const hashBuffer            =  Buffer.from(hashBytes)
+		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
+	});
 
-	// 	expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
-	// });
-
-	// it("should decode HoloHash string into HoloHash buffer", async () => {
-	// 	const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
-	// 	const holoHashBytes					= new Uint8Array([
-	// 		132, 33,  36,	 88,	43,  0,	 	130, 130,
-	// 		164, 145, 252, 50,	36,  8,   37,	 143,
-	// 		125, 49,  95,  241, 139, 45,  95,	 183,
-	// 		5,	 123, 133, 203, 141, 250, 107, 100, 
-	// 		170, 165, 193, 48,  200, 28,  230
-	// 	]);
-
-	// 	const holoHashBuffer            =  Buffer.from(holoHashBytes);
-
-	// 	expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
-	// });
-
-	it("should encode raw buffer into HoloHash string", async () => {
+	it("should encode stringified data into base64 encoded SHA-256 multihash", async () => {
 		const jsonData				=  {
 			"test": "information",
-			"this": {
-				"will": ["be hashed into", "a sha256 then", "put into a holohash"],
-				"number": 1
+			"steps": {
+				"process": ["data will be hashed into a", "sha256 multihash then", "encoded"],
+				"base": 64
 			}
 		};
-		
-		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+
+		const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
 		
 		expect( Codec.Digest.encode(jsonData)).to.equal(hashString);
+	});
+
+	it("should encode sha256 digest buffer into base64 encoded SHA-256 multihash", async () => {
+		const hashBytes					= new Uint8Array([
+			123,34,115,116,101,112,115,34,58,123,34,98,97,115,101,34,58,54,52,44,34,112,114,111,99,101,115,115,34,58,91,34,100,97,116,97,32,119,105,108,108,32,98,101,32,104,97,115,104,101,100,32,105,110,116,111,32,97,34,44,34,115,104,97,50,53,54,32,109,117,108,116,105,104,97,115,104,32,116,104,101,110,34,44,34,101,110,99,111,100,101,100,34,93,125,44,34,116,101,115,116,34,58,34,105,110,102,111,114,109,97,116,105,111,110,34,125
+		]);
+		const hashBuffer            =  Buffer.from(hashBytes)
+		
+		const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
+		
+		expect( Codec.Digest.encode(hashBuffer)).to.equal(hashString);
 	});
 });

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -148,9 +148,7 @@ describe("Codec.HoloHash", () => {
 
 		const holoHashBuffer            =  Buffer.from(holoHashBytes);
 
-		const HOLO_HASH_ENTRY_PREFIX	= Buffer.from(new Uint8Array([0x84, 0x21, 0x24]).buffer);
-
-		expect( Codec.HoloHash.holoHashFromBuffer(HOLO_HASH_ENTRY_PREFIX, dataBuffer)	).to.deep.equal(holoHashBuffer);
+		expect( Codec.HoloHash.holoHashFromBuffer('entry', dataBuffer)	).to.deep.equal(holoHashBuffer);
 	});
 
 	it("should decode HoloHash string into raw buffer", async () => {

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -6,7 +6,7 @@ const { Codec }						= require('../src/index.js');
 const sha256						= (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
 
 describe("Codec.AgentId", () => {
-	it("should get Holochain HoloHash agent ID buffer from public key buffer", () => {
+	it("should get HoloHash agent pubkey buffer from public key buffer", () => {
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
 			197,  77,  22,   0, 199, 102, 199,
@@ -16,19 +16,19 @@ describe("Codec.AgentId", () => {
 		]);
 		const publicKeyBuffer            =  Buffer.from(publicKey);
 
-		const agentId					= new Uint8Array([
+		const holohashPubKey					= new Uint8Array([
 			132,  32,  36, 161, 222, 128, 146, 233,
 			128,  11, 197,  77,  22,   0, 199, 102,
 			199, 105,  12,  19, 193,  24, 250,  79,
 			198, 221, 144, 203,  23, 155, 141, 142,
 			179, 124, 113, 144,  10,  68, 169
 		]);
-		const agentIdBuffer            =  Buffer.from(agentId);
+		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
 
-		expect( Codec.AgentId.holoHashFromPublicKey(publicKeyBuffer)	).to.deep.equal(agentIdBuffer);
+		expect( Codec.AgentId.holoHashFromPublicKey(publicKeyBuffer)	).to.deep.equal(holohashPubKeyBuffer);
 	})
 
-	it("should decode Holochain HoloHash agent ID into public key bytes", () => {
+	it("should decode HoloHash agent ID into public key bytes", () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
@@ -37,21 +37,51 @@ describe("Codec.AgentId", () => {
 			198, 221, 144, 203,  23, 155, 141,
 			142, 179, 124, 113
 		]);
+		const publicKeyBuffer            =  Buffer.from(publicKey);
 
-		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKey);
+		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKeyBuffer);
 	})
 
-	it("should encode public key bytes into Holochain HoloHash agent ID", () => {
-			const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-			const publicKey					= new Uint8Array([
-				161, 222, 128, 146, 233, 128,  11,
-				197,  77,  22,   0, 199, 102, 199,
-				105,  12,  19, 193,  24, 250,  79,
-				198, 221, 144, 203,  23, 155, 141,
-				142, 179, 124, 113
-			]);
+	it("should decode HoloHash agent ID into HoloHash agent pubkey buffer", async () => {
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const holohashPubKey					= new Uint8Array([
+			132,  32,  36, 161, 222, 128, 146, 233,
+			128,  11, 197,  77,  22,   0, 199, 102,
+			199, 105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141, 142,
+			179, 124, 113, 144,  10,  68, 169
+		]);
+		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
 
-			expect( Codec.AgentId.encode(publicKey)		).to.equal(agentId);
+		expect( Codec.Digest.decodeToHoloHash(agentId)).to.deep.equal(holohashPubKeyBuffer);
+	});
+
+	it("should encode public key bytes into HoloHash agent ID", () => {
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const publicKey					= new Uint8Array([
+			161, 222, 128, 146, 233, 128,  11,
+			197,  77,  22,   0, 199, 102, 199,
+			105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141,
+			142, 179, 124, 113
+		]);
+		const publicKeyBuffer            =  Buffer.from(publicKey);
+
+		expect( Codec.AgentId.encode(publicKeyBuffer)		).to.equal(agentId);
+	});
+
+	it("should encode HoloHash agent pubkey into HoloHash agent ID", () => {
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const holohashPubKey					= new Uint8Array([
+			132,  32,  36, 161, 222, 128, 146, 233,
+			128,  11, 197,  77,  22,   0, 199, 102,
+			199, 105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141, 142,
+			179, 124, 113, 144,  10,  68, 169
+		]);
+		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
+
+		expect( Codec.AgentId.encodeFromHoloHash(holohashPubKeyBuffer)		).to.equal(agentId);
 	});
 });
 
@@ -123,9 +153,30 @@ describe("Codec.Base64", () => {
 			140, 118, 203, 210, 129, 206,  234
 		]);
 		const hashBuf					 = Buffer.from(dataBytes)
-		const hashString				= "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+		const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
 
-		expect( Codec.Base64.encode(hashBuf)).to.equal(hashString);
+		expect( Codec.Base64.encode(hashBuf)).to.equal(base64String);
+	});
+
+	it("should get HoloHash base64 String from raw base64 string", async () => {
+		const base64String				 = "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+		const HHBase64String			 = "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+
+		expect( Codec.Base64.base64ToHoloHashB64(base64String)).to.equal(HHBase64String);
+	});
+
+	it("should encode buffer into HoloHash base64 string", async () => {
+		const dataBytes					= new Uint8Array([
+			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
+			63,  7,   31,  208, 188,  164, 15,  85, 
+			43,  151, 1,   95, 	44, 	44,  114, 137, 
+			94,  184, 122, 101, 47, 	24,  85,  237,
+			140, 118, 203, 210, 129, 206,  234
+		]);
+		const hashBuf					 = Buffer.from(dataBytes)
+		const HHBase64String			 = "hCAkTFYCB48_Bx_QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+
+		expect( Codec.Base64.encodeToHoloHashB64(hashBuf)).to.equal(HHBase64String);
 	});
 });
 
@@ -197,7 +248,7 @@ describe("Codec.Digest", () => {
 		const holoHashBuffer            =  Buffer.from(holoHashBytes);
 
 		expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
-});
+	});
 
 	it("should encode raw buffer into HoloHash string", async () => {
 		const data					= new Uint8Array([
@@ -207,7 +258,7 @@ describe("Codec.Digest", () => {
 			203, 141,	250, 107,	100, 170, 165, 193
 		]);
 
-		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
+		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 
 		expect( Codec.Digest.encode('entry', data)).to.equal(hashString);
 	});

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -184,7 +184,7 @@ describe("Codec.Digest", () => {
 		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
 	});
 
-	it("should decode HoloHash String into Buffer", async () => {
+	it("should decode HoloHash String into HoloHash Buffer", async () => {
 		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const holoHashBytes					= new Uint8Array([
 			132, 33,  36,	 88,	43,  0,	 	130, 130,

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -29,7 +29,7 @@ describe("Codec.AgentId", () => {
 	})
 
 	it("should decode Holochain HoloHash agent ID into public key bytes", () => {
-		const agentId					= "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
 			197,  77,  22,   0, 199, 102, 199,
@@ -42,7 +42,7 @@ describe("Codec.AgentId", () => {
 	})
 
 	it("should encode public key bytes into Holochain HoloHash agent ID", () => {
-			const agentId					= "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+			const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 			const publicKey					= new Uint8Array([
 				161, 222, 128, 146, 233, 128,  11,
 				197,  77,  22,   0, 199, 102, 199,
@@ -172,7 +172,7 @@ describe("Codec.Digest", () => {
 	})
 
 	it("should decode HoloHash string into raw buffer", async () => {
-		const hashString				= "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const hashBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,
@@ -185,7 +185,7 @@ describe("Codec.Digest", () => {
 	});
 
 	it("should decode HoloHash string into HoloHash buffer", async () => {
-		const hashString				= "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const holoHashBytes					= new Uint8Array([
 			132, 33,  36,	 88,	43,  0,	 	130, 130,
 			164, 145, 252, 50,	36,  8,   37,	 143,
@@ -207,7 +207,7 @@ describe("Codec.Digest", () => {
 			203, 141,	250, 107,	100, 170, 165, 193
 		]);
 
-		const hashString				=  "hCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
+		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
 
 		expect( Codec.Digest.encode('entry', data)).to.equal(hashString);
 	});

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -5,43 +5,24 @@ const { Codec }						= require('../src/index.js');
 describe("Codec.AgentId", () => {
 	it("should decode HoloHash agent ID into HoloHash agent pubkey buffer", async () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-		const holohashPubKey					= new Uint8Array([
-			132,  32,  36, 161, 222, 128, 146, 233,
-			128,  11, 197,  77,  22,   0, 199, 102,
-			199, 105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141, 142,
-			179, 124, 113, 144,  10,  68, 169
-		]);
-		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
+		const agentHoloHashb64			= "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const holohashPubKeyBuffer            = Buffer.from(agentHoloHashb64, "base64" );
 
 		expect( Codec.AgentId.decodeToHoloHash(agentId)).to.deep.equal(holohashPubKeyBuffer);
 	});
 
 	it("should decode HoloHash agent ID into public key buffer", () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-		const publicKey					= new Uint8Array([
-			161, 222, 128, 146, 233, 128,  11,
-			197,  77,  22,   0, 199, 102, 199,
-			105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141,
-			142, 179, 124, 113
-		]);
-		const publicKeyBuffer            =  Buffer.from(publicKey);
+		const publicKeyb64 				= "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE";
+		const publicKeyBuffer           =  Buffer.from(publicKeyb64, "base64");
 
 		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKeyBuffer);
 	});
 
 	it("should encode public key buffer into HoloHash agent ID", () => {
+		const publicKeyb64 				= "od6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHE";
+		const publicKeyBuffer           =  Buffer.from(publicKeyb64, "base64");
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-		const publicKey					= new Uint8Array([
-			161, 222, 128, 146, 233, 128,  11,
-			197,  77,  22,   0, 199, 102, 199,
-			105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141,
-			142, 179, 124, 113
-		]);
-		const publicKeyBuffer            =  Buffer.from(publicKey);
-
 		expect( Codec.AgentId.encode(publicKeyBuffer)		).to.equal(agentId);
 	});
 });
@@ -49,26 +30,14 @@ describe("Codec.AgentId", () => {
 describe("Codec.Base36", () => {
 	it("should decode agent ID using base36", async () => {
 		const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
-		const publicKey					= new Uint8Array([
-			1,   2,   3,   4,   5,   6,   7,
-			8,   9,  10,  11,  12,  13,  14,
-			15,  16,  17,  18,  19,  20,  21,
-			22,  23,  24,  25,  26,  27,  28,
-			29,  30,  31,  32
-		]);
+		const publicKey					= Buffer.from("AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=", "base64");
 
 		expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
 	});
 
 	it("should encode agent ID into base36", async () => {
+		const publicKey					= Buffer.from("AQIDBAUGBwgJCgsMDQ4PEBESExQVFhcYGRobHB0eHyA=", "base64");
 		const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
-		const publicKey					= new Uint8Array([
-			1,   2,   3,   4,   5,   6,   7,
-			8,   9,  10,  11,  12,  13,  14,
-			15,  16,  17,  18,  19,  20,  21,
-			22,  23,  24,  25,  26,  27,  28,
-			29,  30,  31,  32
-		]);
 
 		expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
 	});
@@ -99,81 +68,40 @@ describe("Codec.HoloHash", () => {
 	});
 
 	it("should return holohash buffer from raw buffer", () => {
-		const dataBytes					= new Uint8Array([
-			88,	 43,  0,	 130,	130, 164, 145, 252,
-			50,	 36,  8,	 37,	143, 125, 49,	 95,
-			241, 139, 45,	 95,	183, 5,		123, 133,	
-			203, 141,	250, 107,	100, 170, 165, 193
-		]);
-		const dataBuffer            =  Buffer.from(dataBytes);
-
-		const holoHashBytes					= new Uint8Array([
-			132, 33,  36,	 88,	43,  0,	 	130, 130,
-			164, 145, 252, 50,	36,  8,   37,	 143,
-			125, 49,  95,  241, 139, 45,  95,	 183,
-			5,	 123, 133, 203, 141, 250, 107, 100, 
-			170, 165, 193, 48,  200, 28,  230
-		]);
-
-		const holoHashBuffer            =  Buffer.from(holoHashBytes);
+		const dataBuffer            	=  Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
+		const holoHashBuffer            =  Buffer.from("hCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm", "base64");
 
 		expect( Codec.HoloHash.holoHashFromBuffer('entry', dataBuffer)	).to.deep.equal(holoHashBuffer);
 	});
 
 	it("should decode HoloHash string into raw buffer", async () => {
 		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
-		const hashBytes					= new Uint8Array([
-			88,	 43,  0,	 130,	130, 164, 145, 252,
-			50,	 36,  8,	 37,	143, 125, 49,	 95,
-			241, 139, 45,	 95,	183, 5,		123, 133,	
-			203, 141,	250, 107,	100, 170, 165, 193
-		]);
-		const hashBuffer            =  Buffer.from(hashBytes)
+		const hashBuffer            	=  Buffer.from( "WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64" );
 
 		expect( Codec.HoloHash.decode(hashString)).to.deep.equal(hashBuffer);
 	});
 
 	it("should encode raw buffer into HoloHash string", async () => {
-		const bytes					= new Uint8Array([
-			88,	 43,  0,	 130,	130, 164, 145, 252,
-			50,	 36,  8,	 37,	143, 125, 49,	 95,
-			241, 139, 45,	 95,	183, 5,		123, 133,	
-			203, 141,	250, 107,	100, 170, 165, 193
-		]);
-
-		const buffer            =  Buffer.from(bytes);
-
+		const rawBuffer 				= Buffer.from("WCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcE=", "base64");
 		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 
-		expect( Codec.HoloHash.encode('entry', buffer)).to.equal(hashString);
+		expect( Codec.HoloHash.encode('entry', rawBuffer)).to.equal(hashString);
 	});
 
 	it("should encode holohash buffer into HoloHash string", async () => {
-		const holoHashBytes					= new Uint8Array([
-			132, 33,  36,	 88,	43,  0,	 	130, 130,
-			164, 145, 252, 50,	36,  8,   37,	 143,
-			125, 49,  95,  241, 139, 45,  95,	 183,
-			5,	 123, 133, 203, 141, 250, 107, 100, 
-			170, 165, 193, 48,  200, 28,  230
-		]);
-
-		const holoHashBuffer            =  Buffer.from(holoHashBytes);
-
+		const holoHashBuffer   			= Buffer.from("hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm", "base64");
 		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 
 		expect( Codec.HoloHash.encode('entry', holoHashBuffer)).to.equal(hashString);
 	});
 });
 
-
 describe("Codec.Digest", () => {
 	it("should decode SHA-256 multihash into SHA-256 digest buffer", async () => {
 		const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
-		const hashBytes					= new Uint8Array([
-			123,34,115,116,101,112,115,34,58,123,34,98,97,115,101,34,58,54,52,44,34,112,114,111,99,101,115,115,34,58,91,34,100,97,116,97,32,119,105,108,108,32,98,101,32,104,97,115,104,101,100,32,105,110,116,111,32,97,34,44,34,115,104,97,50,53,54,32,109,117,108,116,105,104,97,115,104,32,116,104,101,110,34,44,34,101,110,99,111,100,101,100,34,93,125,44,34,116,101,115,116,34,58,34,105,110,102,111,114,109,97,116,105,111,110,34,125
-		]);
-		const hashBuffer            =  Buffer.from(hashBytes)
-		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
+		const hashDigest				= "eyJzdGVwcyI6eyJiYXNlIjo2NCwicHJvY2VzcyI6WyJkYXRhIHdpbGwgYmUgaGFzaGVkIGludG8gYSIsInNoYTI1NiBtdWx0aWhhc2ggdGhlbiIsImVuY29kZWQiXX0sInRlc3QiOiJpbmZvcm1hdGlvbiJ9";
+		const digestBuffer            	=  Buffer.from(hashDigest, "base64");
+		expect( Codec.Digest.decode(hashString)).to.deep.equal(digestBuffer);
 	});
 
 	it("should encode stringified data into base64 encoded SHA-256 multihash", async () => {
@@ -191,13 +119,10 @@ describe("Codec.Digest", () => {
 	});
 
 	it("should encode sha256 digest buffer into base64 encoded SHA-256 multihash", async () => {
-		const hashBytes					= new Uint8Array([
-			123,34,115,116,101,112,115,34,58,123,34,98,97,115,101,34,58,54,52,44,34,112,114,111,99,101,115,115,34,58,91,34,100,97,116,97,32,119,105,108,108,32,98,101,32,104,97,115,104,101,100,32,105,110,116,111,32,97,34,44,34,115,104,97,50,53,54,32,109,117,108,116,105,104,97,115,104,32,116,104,101,110,34,44,34,101,110,99,111,100,101,100,34,93,125,44,34,116,101,115,116,34,58,34,105,110,102,111,114,109,97,116,105,111,110,34,125
-		]);
-		const hashBuffer            =  Buffer.from(hashBytes)
+		const hashDigest					= "eyJzdGVwcyI6eyJiYXNlIjo2NCwicHJvY2VzcyI6WyJkYXRhIHdpbGwgYmUgaGFzaGVkIGludG8gYSIsInNoYTI1NiBtdWx0aWhhc2ggdGhlbiIsImVuY29kZWQiXX0sInRlc3QiOiJpbmZvcm1hdGlvbiJ9";
+		const digestBuffer           	 	=  Buffer.from(hashDigest, "base64");
+		const hashString					=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
 		
-		const hashString				=  "EnV7InN0ZXBzIjp7ImJhc2UiOjY0LCJwcm9jZXNzIjpbImRhdGEgd2lsbCBiZSBoYXNoZWQgaW50byBhIiwic2hhMjU2IG11bHRpaGFzaCB0aGVuIiwiZW5jb2RlZCJdfSwidGVzdCI6ImluZm9ybWF0aW9uIn0=";
-		
-		expect( Codec.Digest.encode(hashBuffer)).to.equal(hashString);
+		expect( Codec.Digest.encode(digestBuffer)).to.equal(hashString);
 	});
 });

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -6,7 +6,7 @@ const { Codec }						= require('../src/index.js');
 const sha256						= (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
 
 describe("Codec.AgentId", () => {
-	it("should get holochain agent ID buffer from public key buffer", () => {
+	it("should get Holochain HoloHash agent ID buffer from public key buffer", () => {
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
 			197,  77,  22,   0, 199, 102, 199,
@@ -28,7 +28,7 @@ describe("Codec.AgentId", () => {
 		expect( Codec.AgentId.holoHashFromPublicKey(publicKeyBuffer)	).to.deep.equal(agentIdBuffer);
 	})
 
-	it("should decode agent ID into public key bytes", () => {
+	it("should decode Holochain HoloHash agent ID into public key bytes", () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
@@ -38,10 +38,10 @@ describe("Codec.AgentId", () => {
 			142, 179, 124, 113
 		]);
 
-expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKey);
+		expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKey);
 	})
 
-	it("should encode public key bytes into agent ID", () => {
+	it("should encode public key bytes into Holochain HoloHash agent ID", () => {
 			const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 			const publicKey					= new Uint8Array([
 				161, 222, 128, 146, 233, 128,  11,
@@ -91,7 +91,7 @@ describe("Codec.Base58", () => {
 		expect( Codec.Base58.decode(hashString)).to.deep.equal(hashBytes);
 	});
 
-	it("should encode SHA-256 digest bytes into SHA-256 multihash (with base658)", async () => {
+	it("should encode SHA-256 digest bytes into SHA-256 multihash (with base58)", async () => {
 		const hashBytes					= await sha256(new Uint8Array([0xba, 0xbe]));
 		const hashString				= "QmeTu8d5sUNULwS72NxLNTMhLZfPma4qcWvG2LqxiUz1Gf";
 
@@ -147,7 +147,7 @@ describe("Codec.Signature", () => {
 });
 
 describe("Codec.Digest", () => {
-	it("should get holohash from data buffer", () => {
+	it("should get holohash buffer from raw buffer", () => {
 		const dataBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,
@@ -171,7 +171,7 @@ describe("Codec.Digest", () => {
 		expect( Codec.Digest.holoHashFromBuffer(HOLO_HASH_ENTRY_PREFIX, dataBuffer)	).to.deep.equal(holoHashBuffer);
 	})
 
-	it("should decode HoloHash String into Buffer", async () => {
+	it("should decode HoloHash string into raw buffer", async () => {
 		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const hashBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
@@ -184,7 +184,7 @@ describe("Codec.Digest", () => {
 		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
 	});
 
-	it("should decode HoloHash String into HoloHash Buffer", async () => {
+	it("should decode HoloHash string into HoloHash buffer", async () => {
 		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const holoHashBytes					= new Uint8Array([
 			132, 33,  36,	 88,	43,  0,	 	130, 130,
@@ -199,7 +199,7 @@ describe("Codec.Digest", () => {
 		expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
 });
 
-	it("should encode Buffer into HoloHash", async () => {
+	it("should encode raw buffer into HoloHash string", async () => {
 		const data					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -6,28 +6,6 @@ const { Codec }						= require('../src/index.js');
 const sha256						= (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
 
 describe("Codec.AgentId", () => {
-	it("should get HoloHash agent pubkey buffer from public key buffer", () => {
-		const publicKey					= new Uint8Array([
-			161, 222, 128, 146, 233, 128,  11,
-			197,  77,  22,   0, 199, 102, 199,
-			105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141,
-			142, 179, 124, 113
-		]);
-		const publicKeyBuffer            =  Buffer.from(publicKey);
-
-		const holohashPubKey					= new Uint8Array([
-			132,  32,  36, 161, 222, 128, 146, 233,
-			128,  11, 197,  77,  22,   0, 199, 102,
-			199, 105,  12,  19, 193,  24, 250,  79,
-			198, 221, 144, 203,  23, 155, 141, 142,
-			179, 124, 113, 144,  10,  68, 169
-		]);
-		const holohashPubKeyBuffer            =  Buffer.from(holohashPubKey);
-
-		expect( Codec.AgentId.holoHashFromPublicKey(publicKeyBuffer)	).to.deep.equal(holohashPubKeyBuffer);
-	})
-
 	it("should decode HoloHash agent ID into public key bytes", () => {
 		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
@@ -197,7 +175,7 @@ describe("Codec.Signature", () => {
 	});
 });
 
-describe("Codec.Digest", () => {
+describe("Codec.HoloHash", () => {
 	it("should get holohash buffer from raw buffer", () => {
 		const dataBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
@@ -219,8 +197,8 @@ describe("Codec.Digest", () => {
 
 		const HOLO_HASH_ENTRY_PREFIX	= Buffer.from(new Uint8Array([0x84, 0x21, 0x24]).buffer);
 
-		expect( Codec.Digest.holoHashFromBuffer(HOLO_HASH_ENTRY_PREFIX, dataBuffer)	).to.deep.equal(holoHashBuffer);
-	})
+		expect( Codec.HoloHash.holoHashFromBuffer(HOLO_HASH_ENTRY_PREFIX, dataBuffer)	).to.deep.equal(holoHashBuffer);
+	});
 
 	it("should decode HoloHash string into raw buffer", async () => {
 		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
@@ -232,22 +210,7 @@ describe("Codec.Digest", () => {
 		]);
 		const hashBuffer            =  Buffer.from(hashBytes)
 
-		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
-	});
-
-	it("should decode HoloHash string into HoloHash buffer", async () => {
-		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
-		const holoHashBytes					= new Uint8Array([
-			132, 33,  36,	 88,	43,  0,	 	130, 130,
-			164, 145, 252, 50,	36,  8,   37,	 143,
-			125, 49,  95,  241, 139, 45,  95,	 183,
-			5,	 123, 133, 203, 141, 250, 107, 100, 
-			170, 165, 193, 48,  200, 28,  230
-		]);
-
-		const holoHashBuffer            =  Buffer.from(holoHashBytes);
-
-		expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
+		expect( Codec.HoloHash.decode(hashString)).to.deep.equal(hashBuffer);
 	});
 
 	it("should encode raw buffer into HoloHash string", async () => {
@@ -260,6 +223,51 @@ describe("Codec.Digest", () => {
 
 		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 
-		expect( Codec.Digest.encode('entry', data)).to.equal(hashString);
+		expect( Codec.HoloHash.encode('entry', data)).to.equal(hashString);
+	});
+});
+
+
+describe("Codec.Digest", () => {
+	// it("should decode HoloHash string into raw buffer", async () => {
+	// 	const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+	// 	const hashBytes					= new Uint8Array([
+	// 		88,	 43,  0,	 130,	130, 164, 145, 252,
+	// 		50,	 36,  8,	 37,	143, 125, 49,	 95,
+	// 		241, 139, 45,	 95,	183, 5,		123, 133,	
+	// 		203, 141,	250, 107,	100, 170, 165, 193
+	// 	]);
+	// 	const hashBuffer            =  Buffer.from(hashBytes)
+
+	// 	expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
+	// });
+
+	// it("should decode HoloHash string into HoloHash buffer", async () => {
+	// 	const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+	// 	const holoHashBytes					= new Uint8Array([
+	// 		132, 33,  36,	 88,	43,  0,	 	130, 130,
+	// 		164, 145, 252, 50,	36,  8,   37,	 143,
+	// 		125, 49,  95,  241, 139, 45,  95,	 183,
+	// 		5,	 123, 133, 203, 141, 250, 107, 100, 
+	// 		170, 165, 193, 48,  200, 28,  230
+	// 	]);
+
+	// 	const holoHashBuffer            =  Buffer.from(holoHashBytes);
+
+	// 	expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
+	// });
+
+	it("should encode raw buffer into HoloHash string", async () => {
+		const jsonData				=  {
+			"test": "information",
+			"this": {
+				"will": ["be hashed into", "a sha256 then", "put into a holohash"],
+				"number": 1
+			}
+		};
+		
+		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		
+		expect( Codec.Digest.encode(jsonData)).to.equal(hashString);
 	});
 });

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -29,7 +29,7 @@ describe("Codec.AgentId", () => {
 	})
 
 	it("should decode Holochain HoloHash agent ID into public key bytes", () => {
-		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const agentId					= "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 		const publicKey					= new Uint8Array([
 			161, 222, 128, 146, 233, 128,  11,
 			197,  77,  22,   0, 199, 102, 199,
@@ -42,7 +42,7 @@ describe("Codec.AgentId", () => {
 	})
 
 	it("should encode public key bytes into Holochain HoloHash agent ID", () => {
-			const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+			const agentId					= "hCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
 			const publicKey					= new Uint8Array([
 				161, 222, 128, 146, 233, 128,  11,
 				197,  77,  22,   0, 199, 102, 199,
@@ -172,7 +172,7 @@ describe("Codec.Digest", () => {
 	})
 
 	it("should decode HoloHash string into raw buffer", async () => {
-		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const hashString				= "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const hashBytes					= new Uint8Array([
 			88,	 43,  0,	 130,	130, 164, 145, 252,
 			50,	 36,  8,	 37,	143, 125, 49,	 95,
@@ -185,7 +185,7 @@ describe("Codec.Digest", () => {
 	});
 
 	it("should decode HoloHash string into HoloHash buffer", async () => {
-		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const hashString				= "hCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
 		const holoHashBytes					= new Uint8Array([
 			132, 33,  36,	 88,	43,  0,	 	130, 130,
 			164, 145, 252, 50,	36,  8,   37,	 143,
@@ -207,7 +207,7 @@ describe("Codec.Digest", () => {
 			203, 141,	250, 107,	100, 170, 165, 193
 		]);
 
-		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
+		const hashString				=  "hCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
 
 		expect( Codec.Digest.encode('entry', data)).to.equal(hashString);
 	});

--- a/tests/test_codec.js
+++ b/tests/test_codec.js
@@ -6,108 +6,209 @@ const { Codec }						= require('../src/index.js');
 const sha256						= (buf) => crypto.createHash('sha256').update( Buffer.from(buf) ).digest();
 
 describe("Codec.AgentId", () => {
-    it("should get agent ID bytes from public key bytes", () => {
-        const publicKey					= new Uint8Array([
-            161, 222, 128, 146, 233, 128,  11,
-            197,  77,  22,   0, 199, 102, 199,
-            105,  12,  19, 193,  24, 250,  79,
-            198, 221, 144, 203,  23, 155, 141,
-            142, 179, 124, 113
-        ]);
-        const agentId					= new Uint8Array([
-	    132,  32,  36, 161, 222, 128, 146, 233,
-	    128,  11, 197,  77,  22,   0, 199, 102,
-	    199, 105,  12,  19, 193,  24, 250,  79,
-	    198, 221, 144, 203,  23, 155, 141, 142,
-	    179, 124, 113, 144,  10,  68, 169
-	]);
+	it("should get holochain agent ID buffer from public key buffer", () => {
+		const publicKey					= new Uint8Array([
+			161, 222, 128, 146, 233, 128,  11,
+			197,  77,  22,   0, 199, 102, 199,
+			105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141,
+			142, 179, 124, 113
+		]);
+		const publicKeyBuffer            =  Buffer.from(publicKey);
 
-	expect( Codec.AgentId.fromPublicKey(publicKey)	).to.deep.equal(agentId);
-    })
+		const agentId					= new Uint8Array([
+			132,  32,  36, 161, 222, 128, 146, 233,
+			128,  11, 197,  77,  22,   0, 199, 102,
+			199, 105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141, 142,
+			179, 124, 113, 144,  10,  68, 169
+		]);
+		const agentIdBuffer            =  Buffer.from(agentId);
 
-    it("should decode agent ID into public key bytes", () => {
-        const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-        const publicKey					= new Uint8Array([
-            161, 222, 128, 146, 233, 128,  11,
-            197,  77,  22,   0, 199, 102, 199,
-            105,  12,  19, 193,  24, 250,  79,
-            198, 221, 144, 203,  23, 155, 141,
-            142, 179, 124, 113
-        ]);
+		expect( Codec.AgentId.holoHashFromPublicKey(publicKeyBuffer)	).to.deep.equal(agentIdBuffer);
+	})
 
-	expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKey);
-    })
+	it("should decode agent ID into public key bytes", () => {
+		const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+		const publicKey					= new Uint8Array([
+			161, 222, 128, 146, 233, 128,  11,
+			197,  77,  22,   0, 199, 102, 199,
+			105,  12,  19, 193,  24, 250,  79,
+			198, 221, 144, 203,  23, 155, 141,
+			142, 179, 124, 113
+		]);
 
-    it("should encode public key bytes into agent ID", () => {
-        const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
-        const publicKey					= new Uint8Array([
-            161, 222, 128, 146, 233, 128,  11,
-            197,  77,  22,   0, 199, 102, 199,
-            105,  12,  19, 193,  24, 250,  79,
-            198, 221, 144, 203,  23, 155, 141,
-            142, 179, 124, 113
-        ]);
+expect( Codec.AgentId.decode(agentId)		).to.deep.equal(publicKey);
+	})
 
-        expect( Codec.AgentId.encode(publicKey)		).to.equal(agentId);
-    });
+	it("should encode public key bytes into agent ID", () => {
+			const agentId					= "uhCAkod6AkumAC8VNFgDHZsdpDBPBGPpPxt2QyxebjY6zfHGQCkSp";
+			const publicKey					= new Uint8Array([
+				161, 222, 128, 146, 233, 128,  11,
+				197,  77,  22,   0, 199, 102, 199,
+				105,  12,  19, 193,  24, 250,  79,
+				198, 221, 144, 203,  23, 155, 141,
+				142, 179, 124, 113
+			]);
+
+			expect( Codec.AgentId.encode(publicKey)		).to.equal(agentId);
+	});
 });
 
 describe("Codec.Base36", () => {
-    it("should decode agent ID using base36", async () => {
-        const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
-        const publicKey					= new Uint8Array([
-              1,   2,   3,   4,   5,   6,   7,
-              8,   9,  10,  11,  12,  13,  14,
-             15,  16,  17,  18,  19,  20,  21,
-             22,  23,  24,  25,  26,  27,  28,
-             29,  30,  31,  32
-        ]);
+	it("should decode agent ID using base36", async () => {
+		const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
+		const publicKey					= new Uint8Array([
+			1,   2,   3,   4,   5,   6,   7,
+			8,   9,  10,  11,  12,  13,  14,
+			15,  16,  17,  18,  19,  20,  21,
+			22,  23,  24,  25,  26,  27,  28,
+			29,  30,  31,  32
+		]);
 
-        expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
-    });
+		expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
+	});
 
-    it("should encode agent ID into base36", async () => {
-        const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
-        const publicKey					= new Uint8Array([
-              1,   2,   3,   4,   5,   6,   7,
-              8,   9,  10,  11,  12,  13,  14,
-             15,  16,  17,  18,  19,  20,  21,
-             22,  23,  24,  25,  26,  27,  28,
-             29,  30,  31,  32
-        ]);
+	it("should encode agent ID into base36", async () => {
+		const urlAgentId				= "wjzlh5yt3uk0mzpcor0i12ol0rrpxdydzggt4b2fvr8yealc";
+		const publicKey					= new Uint8Array([
+			1,   2,   3,   4,   5,   6,   7,
+			8,   9,  10,  11,  12,  13,  14,
+			15,  16,  17,  18,  19,  20,  21,
+			22,  23,  24,  25,  26,  27,  28,
+			29,  30,  31,  32
+		]);
 
-        expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
-    });
+		expect( Codec.Base36.encode(publicKey)		).to.equal(urlAgentId);
+	});
 });
 
+describe("Codec.Base58", () => {
+	it("should decode SHA-256 multihash into SHA-256 digest bytes (with base58)", async () => {
+		const hashString				= "QmNZAJfVYoCASiPc3uYZXrvhRFbxJLxG18R2Ga4ZXfP4kR";
+		const hashBytes					= await sha256(new Uint8Array([0xca, 0xfe]));
+
+		expect( Codec.Base58.decode(hashString)).to.deep.equal(hashBytes);
+	});
+
+	it("should encode SHA-256 digest bytes into SHA-256 multihash (with base658)", async () => {
+		const hashBytes					= await sha256(new Uint8Array([0xba, 0xbe]));
+		const hashString				= "QmeTu8d5sUNULwS72NxLNTMhLZfPma4qcWvG2LqxiUz1Gf";
+
+		expect( Codec.Base58.encode(hashBytes)).to.equal(hashString);
+	});
+});
+
+describe("Codec.Base64", () => {
+	it("should decode base64 string into buffer", async () => {
+		const hashString				= "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+		const dataBytes					= new Uint8Array([
+			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
+			63,  7,   31,  208, 188,  164, 15,  85, 
+			43,  151, 1,   95, 	44, 	44,  114, 137, 
+			94,  184, 122, 101, 47, 	24,  85,  237,
+			140, 118, 203, 210, 129, 206,  234
+		]);
+		const hashBuf					 = Buffer.from(dataBytes)
+
+			expect( Codec.Base64.decode(hashString)).to.deep.equal(hashBuf);
+	});
+
+	it("should encode buffer into base64 string", async () => {
+		const dataBytes					= new Uint8Array([
+			132, 32,  36,  76, 	86, 	2, 	 7,   143, 
+			63,  7,   31,  208, 188,  164, 15,  85, 
+			43,  151, 1,   95, 	44, 	44,  114, 137, 
+			94,  184, 122, 101, 47, 	24,  85,  237,
+			140, 118, 203, 210, 129, 206,  234
+		]);
+		const hashBuf					 = Buffer.from(dataBytes)
+		const hashString				= "hCAkTFYCB48/Bx/QvKQPVSuXAV8sLHKJXrh6ZS8YVe2MdsvSgc7q";
+
+		expect( Codec.Base64.encode(hashBuf)).to.equal(hashString);
+	});
+});
+
+
 describe("Codec.Signature", () => {
-    it("should decode Signature string into message bytes", async () => {
-        const messageBytes				= Buffer.from("example 1");
-        const base64String				= "ZXhhbXBsZSAx";
+	it("should decode Signature string into message bytes", async () => {
+		const messageBytes				= Buffer.from("example 1");
+		const base64String				= "ZXhhbXBsZSAx";
 
-        expect( Codec.Signature.decode(base64String)	).to.deep.equal(messageBytes)
-    });
+		expect( Codec.Signature.decode(base64String)	).to.deep.equal(messageBytes)
+	});
 
-    it("should encode message bytes into Signature string", async () => {
-        const base64String				= "ZXhhbXBsZSAy";
-        const messageBytes				= Buffer.from("example 2");
+	it("should encode message bytes into Signature string", async () => {
+		const base64String				= "ZXhhbXBsZSAy";
+		const messageBytes				= Buffer.from("example 2");
 
-        expect( Codec.Signature.encode(messageBytes)	).to.equal(base64String);
-    });
+		expect( Codec.Signature.encode(messageBytes)	).to.equal(base64String);
+	});
 });
 
 describe("Codec.Digest", () => {
-    it("should decode SHA-256 multihash into SHA-256 digest bytes", async () => {
-        const hashString				= "QmNZAJfVYoCASiPc3uYZXrvhRFbxJLxG18R2Ga4ZXfP4kR";
-        const hashBytes					= await sha256(new Uint8Array([0xca, 0xfe]));
+	it("should get holohash from data buffer", () => {
+		const dataBytes					= new Uint8Array([
+			88,	 43,  0,	 130,	130, 164, 145, 252,
+			50,	 36,  8,	 37,	143, 125, 49,	 95,
+			241, 139, 45,	 95,	183, 5,		123, 133,	
+			203, 141,	250, 107,	100, 170, 165, 193
+		]);
+		const dataBuffer            =  Buffer.from(dataBytes);
 
-        expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBytes);
-    });
+		const holoHashBytes					= new Uint8Array([
+			132, 33,  36,	 88,	43,  0,	 	130, 130,
+			164, 145, 252, 50,	36,  8,   37,	 143,
+			125, 49,  95,  241, 139, 45,  95,	 183,
+			5,	 123, 133, 203, 141, 250, 107, 100, 
+			170, 165, 193, 48,  200, 28,  230
+		]);
 
-    it("should encode SHA-256 digest bytes into SHA-256 multihash", async () => {
-        const hashBytes					= await sha256(new Uint8Array([0xba, 0xbe]));
-        const hashString				= "QmeTu8d5sUNULwS72NxLNTMhLZfPma4qcWvG2LqxiUz1Gf";
+		const holoHashBuffer            =  Buffer.from(holoHashBytes);
 
-        expect( Codec.Digest.encode(hashBytes)).to.equal(hashString);
-    });
+		const HOLO_HASH_ENTRY_PREFIX	= Buffer.from(new Uint8Array([0x84, 0x21, 0x24]).buffer);
+
+		expect( Codec.Digest.holoHashFromBuffer(HOLO_HASH_ENTRY_PREFIX, dataBuffer)	).to.deep.equal(holoHashBuffer);
+	})
+
+	it("should decode HoloHash String into Buffer", async () => {
+		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const hashBytes					= new Uint8Array([
+			88,	 43,  0,	 130,	130, 164, 145, 252,
+			50,	 36,  8,	 37,	143, 125, 49,	 95,
+			241, 139, 45,	 95,	183, 5,		123, 133,	
+			203, 141,	250, 107,	100, 170, 165, 193
+		]);
+		const hashBuffer            =  Buffer.from(hashBytes)
+
+		expect( Codec.Digest.decode(hashString)).to.deep.equal(hashBuffer);
+	});
+
+	it("should decode HoloHash String into Buffer", async () => {
+		const hashString				= "uhCEkWCsAgoKkkfwyJAglj30xX_GLLV-3BXuFy436a2SqpcEwyBzm";
+		const holoHashBytes					= new Uint8Array([
+			132, 33,  36,	 88,	43,  0,	 	130, 130,
+			164, 145, 252, 50,	36,  8,   37,	 143,
+			125, 49,  95,  241, 139, 45,  95,	 183,
+			5,	 123, 133, 203, 141, 250, 107, 100, 
+			170, 165, 193, 48,  200, 28,  230
+		]);
+
+		const holoHashBuffer            =  Buffer.from(holoHashBytes);
+
+		expect( Codec.Digest.decodeToHoloHash(hashString)).to.deep.equal(holoHashBuffer);
+});
+
+	it("should encode Buffer into HoloHash", async () => {
+		const data					= new Uint8Array([
+			88,	 43,  0,	 130,	130, 164, 145, 252,
+			50,	 36,  8,	 37,	143, 125, 49,	 95,
+			241, 139, 45,	 95,	183, 5,		123, 133,	
+			203, 141,	250, 107,	100, 170, 165, 193
+		]);
+
+		const hashString				=  "uhCEkWCsAgoKkkfwyJAglj30xX/GLLV+3BXuFy436a2SqpcEwyBzm";
+
+		expect( Codec.Digest.encode('entry', data)).to.equal(hashString);
+	});
 });


### PR DESCRIPTION
 ### Updates:
 - adds Codec.HoloHash to manage conversions to/from Holochain HoloHash types
 - adds `decodeToHoloHash` method to Codec.AgentId
 - updates Codec.Digest to encode with base64 to match base of Holochain Holo Hash types
 - adds Holo Hash conversion helper functions
 - updates Holo Hash prefixes to buffers
 - updates readme
 - updates tests